### PR TITLE
fixes #1 & #2

### DIFF
--- a/lib/git_wayback_machine/history.rb
+++ b/lib/git_wayback_machine/history.rb
@@ -16,7 +16,7 @@ module GitWaybackMachine
   private
 
     def raw_entries
-      `git log --pretty=format:'%h|%an|%cr|%s' --graph -#{SIZE}`.split("\n").map do |entry|
+      `git log --pretty=format:'%h|%an|%cr|%s'  -#{SIZE}`.split("\n").map do |entry|
         entry.sub(/\A\s*\*\s*/, "").split("|")
       end
     end


### PR DESCRIPTION
git repositories with branches was breaking as with --graph option they produced more than 4 '|' symbols breaking the parsing content into split
